### PR TITLE
fix recursive options bug

### DIFF
--- a/replace.js
+++ b/replace.js
@@ -12,11 +12,14 @@ module.exports = function(options) {
         options.paths[0] === sharedOptions.paths.default[0] &&
         !options.hasOwnProperty('recursive')) {
         options.paths = ['.'];
-        options.recursive = true;
     }
 
     var lineCount = 0,
         limit = 400; // chars per line
+
+    if (options.r) {
+        options.recursive = true;
+    }
 
     if (!options.color) {
         options.color = "cyan";


### PR DESCRIPTION
Hi, ALMaclaine, 
       replace is a popular lib in npm, but recently i find an error in v1.1.0,  when i debug the code, i found i can not get options.recursive, so when i replace in a directory, it can not be replace, so i open a PR. thanks for you watching
                                                                                                                                           