### PR TITLE
Update minimatch dependency to no vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "chalk": "2.4.2",
-    "minimatch": "3.0.4",
+    "minimatch": "3.0.5",
     "yargs": "^15.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This commit updates the minimatch dependency
to use a later version, one without a know vulnerability. https://github.com/advisories/GHSA-f8q6-p94x-37v3